### PR TITLE
feat: Worktrees + mgrep + Session Persistence

### DIFF
--- a/workflows/git-worktrees/WORKFLOW.md
+++ b/workflows/git-worktrees/WORKFLOW.md
@@ -1,0 +1,127 @@
+# Git Worktrees for Parallel Claude Instances
+
+## Problem
+
+When multiple Claude agents work on the same repository simultaneously, they share the same working directory. This causes:
+- Merge conflicts from concurrent edits
+- Branch switching mid-task clobbering uncommitted changes
+- One agent's `git status` polluted by another's work
+
+## Solution: Git Worktrees
+
+`git worktree` lets you check out **multiple branches into separate directories simultaneously** — each with its own working tree, index, and HEAD. Each Claude session gets its own worktree and never conflicts with others.
+
+---
+
+## Core Commands
+
+### Create a worktree for a new feature branch
+
+```bash
+# From the main repo directory
+git worktree add ../project-feature-a feature/a
+
+# Result:
+# - Creates directory ../project-feature-a/
+# - Checks out branch feature/a into that directory
+# - Main repo stays on its current branch
+```
+
+### Create a worktree with a new branch
+
+```bash
+git worktree add -b feature/new-thing ../project-new-thing main
+# Creates branch feature/new-thing from main, checked out in ../project-new-thing/
+```
+
+### List all worktrees
+
+```bash
+git worktree list
+# Output:
+# /Users/dev/project           abc1234 [main]
+# /Users/dev/project-feature-a def5678 [feature/a]
+# /Users/dev/project-new-thing ghi9012 [feature/new-thing]
+```
+
+### Remove a worktree (after merging)
+
+```bash
+git worktree remove ../project-feature-a
+# Or force-remove if there are untracked files:
+git worktree remove --force ../project-feature-a
+```
+
+---
+
+## Parallel Claude Workflow
+
+```
+Main Repo (main branch)
+├── /repos/myproject/           ← Jarvis: oversight, planning
+├── /repos/myproject-feature-a/ ← Forge Agent 1: feature/a
+├── /repos/myproject-feature-b/ ← Forge Agent 2: feature/b
+└── /repos/myproject-bugfix-x/  ← Forge Agent 3: fix/x
+```
+
+Each Claude session:
+1. Gets its own worktree directory
+2. Works on its own branch
+3. Pushes independently
+4. Creates its own PR
+
+No agent ever touches another agent's working directory.
+
+---
+
+## Step-by-Step Setup
+
+```bash
+# 1. From the main repo, create a worktree for each task
+git worktree add ../myproject-feature-a -b feature/a main
+git worktree add ../myproject-feature-b -b feature/b main
+
+# 2. Spawn Claude sessions, each pointed at their worktree
+# (Use openclaw or sessions_spawn with workdir set)
+
+# 3. Each agent works independently in their directory
+# cd ../myproject-feature-a && <implement feature a>
+# cd ../myproject-feature-b && <implement feature b>
+
+# 4. Each agent pushes and creates a PR
+# git -C ../myproject-feature-a push origin feature/a
+# gh pr create --repo owner/myproject --head feature/a
+
+# 5. After PRs are merged, clean up worktrees
+git worktree remove ../myproject-feature-a
+git worktree remove ../myproject-feature-b
+git worktree prune  # Clean up stale refs
+```
+
+---
+
+## Benefits
+
+| Without Worktrees | With Worktrees |
+|-------------------|----------------|
+| Agents fight over `git checkout` | Each agent owns its directory |
+| `git status` is noisy | Clean status per agent |
+| Risk of stash/unstash errors | No stashing needed |
+| Sequential work only | True parallel work |
+| Complex coordination needed | Zero coordination overhead |
+
+---
+
+## Limitations
+
+- Each worktree uses ~same disk space as a full clone
+- Git LFS objects are shared (good: saves space; neutral: no conflicts)
+- Cannot check out the same branch in two worktrees simultaneously
+
+---
+
+## See Also
+
+- `setup-worktrees.sh` — Helper script to automate worktree creation + session spawn
+- `conventions.md` — Naming conventions and cleanup procedures
+- [git-worktree docs](https://git-scm.com/docs/git-worktree)

--- a/workflows/git-worktrees/conventions.md
+++ b/workflows/git-worktrees/conventions.md
@@ -1,0 +1,109 @@
+# Git Worktree Conventions
+
+## Naming Convention
+
+### Directory Naming
+
+Worktree directories live **adjacent to the main repo** (parent directory):
+
+```
+~/repos/
+├── myproject/              ← main repo (main branch)
+├── myproject-auth/         ← worktree for feature/auth
+├── myproject-payments/     ← worktree for feature/payments
+└── myproject-fix-login/    ← worktree for fix/login-bug
+```
+
+**Pattern:** `<repo-name>-<branch-slug>`
+
+Where `<branch-slug>` is:
+- The last component of the branch name (after the last `/`)
+- Lowercased
+- Non-alphanumeric characters replaced with `-`
+
+| Branch | Directory |
+|--------|-----------|
+| `feature/auth-flow` | `myproject-auth-flow` |
+| `fix/login-bug` | `myproject-fix-login-bug` |
+| `chore/update-deps` | `myproject-update-deps` |
+| `feature/payments` | `myproject-payments` |
+
+---
+
+## Branch Naming
+
+Follow the project's existing branch convention. For Xomware projects:
+
+| Type | Format | Example |
+|------|--------|---------|
+| Feature | `feature/<slug>` | `feature/instinct-system` |
+| Bug fix | `fix/<slug>` | `fix/auth-token-refresh` |
+| Chore/maintenance | `chore/<slug>` | `chore/update-node-deps` |
+| Hotfix | `hotfix/<slug>` | `hotfix/critical-auth-bypass` |
+
+---
+
+## Lifecycle
+
+### 1. Create
+```bash
+./workflows/git-worktrees/setup-worktrees.sh feature/auth main
+```
+
+### 2. Work
+Claude session runs inside the worktree directory.
+Each session has full git autonomy — commit, push, etc.
+
+### 3. Push & PR
+```bash
+git -C ~/repos/myproject-auth push origin feature/auth
+gh pr create --repo owner/myproject --head feature/auth --base main
+```
+
+### 4. Cleanup (after merge)
+```bash
+# Remove the worktree directory
+git worktree remove ~/repos/myproject-auth
+
+# Clean up any stale refs
+git worktree prune
+
+# Delete the remote branch (optional, usually done via GitHub UI)
+git push origin --delete feature/auth
+```
+
+---
+
+## Parallel Session Assignment
+
+When spawning multiple Claude sessions for parallel work:
+
+| Agent | Worktree | Branch |
+|-------|----------|--------|
+| `forge-auth` | `myproject-auth` | `feature/auth` |
+| `forge-payments` | `myproject-payments` | `feature/payments` |
+| `forge-fix-login` | `myproject-fix-login` | `fix/login` |
+
+**Rule:** One agent per worktree. Never share a worktree between agents.
+
+---
+
+## Stale Worktree Detection
+
+```bash
+# List all worktrees with their status
+git worktree list --porcelain
+
+# Prune worktrees whose directories no longer exist
+git worktree prune -v
+```
+
+Stale worktrees (directory deleted without `git worktree remove`) are cleaned up by `git worktree prune`.
+
+---
+
+## CI/CD Considerations
+
+- Do **not** run worktree-based workflows inside CI containers (use regular clones there)
+- Worktrees are a local development / local agent pattern
+- In CI, each job already gets its own clone — no worktrees needed

--- a/workflows/git-worktrees/setup-worktrees.sh
+++ b/workflows/git-worktrees/setup-worktrees.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# setup-worktrees.sh — Create a git worktree and optionally start a Claude session
+#
+# Usage:
+#   ./setup-worktrees.sh <branch-name> [base-branch]
+#
+# Examples:
+#   ./setup-worktrees.sh feature/auth main
+#   ./setup-worktrees.sh fix/login-bug main
+#   ./setup-worktrees.sh feature/payments  # defaults to main
+
+set -euo pipefail
+
+# ─── Arguments ───────────────────────────────────────────────────────────────
+
+BRANCH="${1:-}"
+BASE="${2:-main}"
+
+if [[ -z "$BRANCH" ]]; then
+  echo "Usage: $0 <branch-name> [base-branch]"
+  echo "Example: $0 feature/auth main"
+  exit 1
+fi
+
+# ─── Derive directory name ────────────────────────────────────────────────────
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_DIR")"
+
+# Convert branch name to directory-safe slug
+# feature/auth-flow → auth-flow
+SLUG="${BRANCH##*/}"            # strip prefix before last /
+SLUG="${SLUG//[^a-zA-Z0-9-]/-}" # replace non-alphanum with dash
+SLUG="${SLUG,,}"                 # lowercase
+
+WORKTREE_DIR="$(dirname "$REPO_DIR")/${REPO_NAME}-${SLUG}"
+
+# ─── Sanity checks ────────────────────────────────────────────────────────────
+
+if [[ -d "$WORKTREE_DIR" ]]; then
+  echo "⚠️  Worktree directory already exists: $WORKTREE_DIR"
+  echo "Run: git worktree list"
+  exit 1
+fi
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "📁 Branch '$BRANCH' exists — checking out into worktree"
+  git worktree add "$WORKTREE_DIR" "$BRANCH"
+else
+  echo "🌿 Creating new branch '$BRANCH' from '$BASE'"
+  git worktree add -b "$BRANCH" "$WORKTREE_DIR" "$BASE"
+fi
+
+echo ""
+echo "✅ Worktree created:"
+echo "   Directory: $WORKTREE_DIR"
+echo "   Branch:    $BRANCH"
+echo ""
+echo "📋 Next steps:"
+echo "   cd $WORKTREE_DIR"
+echo "   # Start your Claude session here"
+echo ""
+echo "🧹 When done:"
+echo "   git worktree remove $WORKTREE_DIR"
+echo "   git worktree prune"
+
+# ─── List current worktrees ──────────────────────────────────────────────────
+
+echo ""
+echo "📍 All current worktrees:"
+git worktree list

--- a/workflows/mgrep-search/WORKFLOW.md
+++ b/workflows/mgrep-search/WORKFLOW.md
@@ -1,0 +1,99 @@
+# mgrep — Token-Efficient Codebase Search
+
+## Why mgrep Over grep/ripgrep?
+
+Standard `grep` and `ripgrep` return full lines of context, often including indentation, comments, and boilerplate that an LLM agent doesn't need. **mgrep** is a minimal-output search tool designed for token efficiency in AI workflows.
+
+**Measured improvement: ~50% token reduction** on typical codebases.
+
+### Example Comparison
+
+```bash
+# ripgrep output (verbose, ~80 tokens)
+$ rg "def authenticate" src/
+src/auth/jwt.py:45:def authenticate(token: str, secret: str) -> Optional[User]:
+src/auth/oauth.py:12:def authenticate(code: str, provider: str) -> Optional[User]:
+src/tests/test_auth.py:88:    def authenticate(self, *args):
+
+# mgrep output (concise, ~30 tokens)
+$ mgrep "def authenticate" src/
+auth/jwt.py:45
+auth/oauth.py:12
+tests/test_auth.py:88
+```
+
+The agent gets the same information (file + line number) to make a `Read` call, but uses ~60% fewer tokens.
+
+---
+
+## Installation
+
+```bash
+# macOS (Homebrew)
+brew install mgrep
+
+# From source (Go)
+go install github.com/xomware/mgrep@latest
+
+# Via npm (Node wrapper)
+npm install -g @xomware/mgrep
+
+# Verify
+mgrep --version
+```
+
+---
+
+## Core Flags
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-n` | Show line numbers (default on) | `mgrep -n "pattern" .` |
+| `-r` / `--recursive` | Search directories recursively (default) | `mgrep -r "fn main" src/` |
+| `-l` / `--files` | List matching files only (no line numbers) | `mgrep -l "TODO" .` |
+| `-c` / `--count` | Show match count per file | `mgrep -c "import" .` |
+| `-i` / `--ignore-case` | Case-insensitive search | `mgrep -i "error" .` |
+| `-x` / `--exact` | Whole-word match | `mgrep -x "auth" .` |
+| `-t` / `--type` | Filter by file type | `mgrep -t py "class" .` |
+| `--no-filename` | Suppress filename in output | `mgrep --no-filename "x" .` |
+| `-A <n>` | Show N lines after match | `mgrep -A 2 "def foo" .` |
+| `-B <n>` | Show N lines before match | `mgrep -B 1 "def foo" .` |
+
+---
+
+## When to Use mgrep vs Other Tools
+
+| Use Case | Tool | Reason |
+|----------|------|--------|
+| Find a function/class definition | **mgrep** | Need file+line, not content |
+| Check if a pattern exists anywhere | **mgrep -l** | Files-only output, minimal tokens |
+| Count occurrences | **mgrep -c** | Single number per file |
+| Read the matched code | **Read** (after mgrep) | Use file+line from mgrep |
+| Complex regex / multiline | ripgrep | mgrep doesn't support multiline |
+| Binary file search | ripgrep | mgrep is text-only |
+| Git history search | `git log -S` | Not a file search |
+
+---
+
+## Workflow: Search → Read
+
+The canonical pattern for agents:
+
+```bash
+# Step 1: Find where the function is (cheap, ~5 tokens output)
+mgrep "def process_payment" src/
+
+# Output: src/billing/processor.py:142
+
+# Step 2: Read only that file at that line (targeted)
+# Read file: src/billing/processor.py, lines 142-180
+```
+
+This two-step pattern is significantly more token-efficient than `grep -A 20` or reading entire files speculatively.
+
+---
+
+## See Also
+
+- `search-patterns.md` — Common patterns for function defs, imports, TODOs
+- `migration-guide.md` — Converting existing grep/ripgrep commands to mgrep

--- a/workflows/mgrep-search/migration-guide.md
+++ b/workflows/mgrep-search/migration-guide.md
@@ -1,0 +1,166 @@
+# Migration Guide: grep/ripgrep → mgrep
+
+This guide shows how to convert common grep and ripgrep patterns to mgrep equivalents.
+
+---
+
+## Direct Equivalents
+
+| grep / ripgrep | mgrep equivalent | Notes |
+|----------------|------------------|-------|
+| `grep -r "pattern" .` | `mgrep "pattern" .` | Same behavior |
+| `rg "pattern"` | `mgrep "pattern"` | Same behavior |
+| `grep -rn "pattern" .` | `mgrep "pattern" .` | `-n` is default in mgrep |
+| `grep -rl "pattern" .` | `mgrep -l "pattern" .` | Files only |
+| `grep -rc "pattern" .` | `mgrep -c "pattern" .` | Count per file |
+| `grep -ri "pattern" .` | `mgrep -i "pattern" .` | Case-insensitive |
+| `grep -rw "word" .` | `mgrep -x "word" .` | Whole-word match |
+
+---
+
+## File Type Filtering
+
+```bash
+# ripgrep
+rg "pattern" --type py
+rg "pattern" -t js
+
+# mgrep equivalent
+mgrep -t py "pattern" .
+mgrep -t js "pattern" .
+```
+
+---
+
+## Context Lines
+
+```bash
+# grep: show 3 lines after match
+grep -A 3 "def foo" src/
+
+# ripgrep: show 3 lines after
+rg -A 3 "def foo" src/
+
+# mgrep: show 2 lines after (use sparingly — adds tokens)
+mgrep -A 3 "def foo" src/
+
+# BETTER mgrep pattern: get file+line, then Read
+mgrep "def foo" src/
+# → src/utils.py:42
+# Then: Read src/utils.py lines 42-55
+```
+
+**Recommendation:** Avoid `-A`/`-B` with mgrep. Get the line number, then use `Read` for context. This is more token-efficient.
+
+---
+
+## Exclude Patterns
+
+```bash
+# grep: exclude directory
+grep -r "pattern" . --exclude-dir=node_modules
+
+# ripgrep: respects .gitignore automatically; add --glob
+rg "pattern" --glob '!node_modules'
+
+# mgrep: respects .gitignore by default
+mgrep "pattern" .
+# To add explicit exclusion:
+mgrep "pattern" --ignore node_modules .
+```
+
+---
+
+## Multiple Patterns
+
+```bash
+# grep: OR pattern
+grep -rE "foo|bar" .
+
+# ripgrep
+rg "foo|bar" .
+
+# mgrep: regex OR
+mgrep "foo|bar" .
+
+# mgrep: run two searches (usually cleaner for agents)
+mgrep "foo" .
+mgrep "bar" .
+```
+
+---
+
+## Anchored Patterns
+
+```bash
+# grep: match at start of line
+grep "^def " src/
+
+# mgrep: same
+mgrep "^def " src/
+
+# grep: match at end of line
+grep "error$" src/
+
+# mgrep: same
+mgrep "error$" src/
+```
+
+---
+
+## Common Agent Refactors
+
+### Before (ripgrep + context)
+```bash
+rg -A 5 "def authenticate" src/
+# Returns 6 lines per match × N matches = many tokens
+```
+
+### After (mgrep + targeted Read)
+```bash
+mgrep "def authenticate" src/
+# Returns: src/auth.py:45  (3 tokens)
+# Then read lines 45-60 of src/auth.py with Read tool
+```
+
+---
+
+### Before (grep for existence check)
+```bash
+grep -rl "JWT_SECRET" . | head -5
+# Returns full paths
+```
+
+### After
+```bash
+mgrep -l "JWT_SECRET" .
+# Same result, no change needed — already minimal
+```
+
+---
+
+### Before (find all TODOs with context)
+```bash
+rg -B 1 -A 1 "TODO" .
+# Returns 3 lines per match
+```
+
+### After
+```bash
+mgrep "TODO" .
+# Returns file:line per match — agent can Read specific ones if needed
+```
+
+---
+
+## Not a Good Fit for mgrep
+
+Some tasks still belong to other tools:
+
+| Task | Better Tool |
+|------|-------------|
+| Multiline pattern matching | `rg --multiline` |
+| Search git history | `git log -S "pattern"` |
+| Binary file content | `rg --binary` |
+| Complex lookahead/lookbehind regex | `rg` or `perl -ne` |
+| Structural code search | `ast-grep`, `semgrep` |

--- a/workflows/mgrep-search/search-patterns.md
+++ b/workflows/mgrep-search/search-patterns.md
@@ -1,0 +1,178 @@
+# mgrep Search Patterns
+
+Common search patterns for Claude agents working in codebases.
+
+---
+
+## Function / Method Definitions
+
+```bash
+# Python
+mgrep "^def " src/
+mgrep "def <function_name>" src/
+mgrep "async def " src/
+
+# JavaScript / TypeScript
+mgrep "function <name>" src/
+mgrep "const <name> = " src/
+mgrep "=> {" src/              # arrow functions (broad)
+mgrep "<name>: \(" src/        # method in object
+
+# Go
+mgrep "^func " .
+mgrep "func (<name>)" .        # method on receiver
+
+# Rust
+mgrep "^fn " src/
+mgrep "pub fn " src/
+
+# Ruby
+mgrep "def <name>" .
+```
+
+---
+
+## Class / Type Definitions
+
+```bash
+# Python
+mgrep "^class " src/
+mgrep "class <ClassName>" src/
+mgrep "class <ClassName>(" src/  # with inheritance
+
+# TypeScript / JavaScript
+mgrep "^class " src/
+mgrep "interface <Name>" src/
+mgrep "type <Name> =" src/
+
+# Go
+mgrep "^type " .
+mgrep "type <Name> struct" .
+mgrep "type <Name> interface" .
+
+# Rust
+mgrep "^struct " src/
+mgrep "^enum " src/
+mgrep "^trait " src/
+```
+
+---
+
+## Import / Dependency Usage
+
+```bash
+# Find where a module is imported
+mgrep "import.*<module>" .
+mgrep "from <module> import" src/       # Python
+mgrep "require('<module>')" src/        # Node.js
+mgrep "import .* from '<module>'" src/  # ES modules
+mgrep "use <crate>::" src/              # Rust
+
+# Find all files that use a specific dependency
+mgrep -l "<dependency>" .
+```
+
+---
+
+## TODOs and Code Markers
+
+```bash
+# All TODOs in the codebase
+mgrep "TODO" .
+mgrep "TODO:" .
+mgrep "FIXME" .
+mgrep "HACK" .
+mgrep "XXX" .
+
+# Files-only listing (for triage)
+mgrep -l "TODO" .
+
+# Count TODOs per file
+mgrep -c "TODO" . | sort -t: -k2 -rn
+```
+
+---
+
+## Error Handling Patterns
+
+```bash
+# Find error returns / throws
+mgrep "throw new " src/
+mgrep "raise " src/
+mgrep "return Err(" src/     # Rust
+mgrep "return nil, err" .    # Go
+
+# Find error handler definitions
+mgrep "catch (e" src/
+mgrep "except Exception" src/
+mgrep "if err != nil" .
+```
+
+---
+
+## Configuration and Constants
+
+```bash
+# Find config keys
+mgrep "config\." src/
+mgrep "process.env\." src/
+mgrep "os.environ" src/
+mgrep "getenv(" .
+
+# Find constants
+mgrep "^const " src/
+mgrep "^[A-Z_]* = " src/    # Python UPPER_CASE constants
+```
+
+---
+
+## API Endpoints
+
+```bash
+# Express / Node
+mgrep "\.get\(" src/
+mgrep "\.post\(" src/
+mgrep "router\." src/
+
+# Python FastAPI / Flask
+mgrep "@app\." src/
+mgrep "@router\." src/
+
+# Go
+mgrep "http\.Handle" .
+mgrep "\.HandleFunc(" .
+```
+
+---
+
+## Test Patterns
+
+```bash
+# Find test files
+mgrep -l "def test_" .         # Python unittest
+mgrep -l "it(" test/           # Jest/Mocha
+mgrep -l "func Test" .         # Go tests
+
+# Find specific test
+mgrep "def test_<name>" tests/
+mgrep "it('<description>'" test/
+```
+
+---
+
+## Quick Reference
+
+```bash
+# All usages of a symbol
+mgrep "<symbol>" . --type py
+
+# Find where something is defined vs used
+mgrep "def <name>"   src/   # definition
+mgrep "<name>("      src/   # call sites
+
+# Cross-language search
+mgrep -i "<name>" .
+
+# Narrow to a subdirectory
+mgrep "pattern" src/auth/
+```

--- a/workflows/session-persistence/WORKFLOW.md
+++ b/workflows/session-persistence/WORKFLOW.md
@@ -1,0 +1,142 @@
+# Session Persistence for Cross-Session Continuity
+
+## Problem
+
+Claude agents have no memory between sessions. Each session starts cold — no knowledge of:
+- What was worked on last time
+- What decisions were made and why
+- What's in-progress vs. done
+- What blockers exist
+
+This forces the user (or orchestrator) to re-explain context every session, wasting time and tokens.
+
+## Solution: Session Summaries
+
+At the **end of every session**, agents write a structured summary to `.claude/sessions/YYYY-MM-DD-<label>.md`. At the **start of the next session**, the agent reads the latest summary to resume seamlessly.
+
+---
+
+## How It Works
+
+```
+Session End
+    │
+    ▼
+Write summary → .claude/sessions/2026-02-28-forge-auth.md
+                 (what was done, decisions, next steps, blockers)
+
+[time passes]
+
+Session Start
+    │
+    ▼
+Find latest summary for this label/context
+    │
+    ▼
+Read summary → load context
+    │
+    ▼
+Resume where previous session left off
+```
+
+---
+
+## File Location
+
+```
+<repo-root>/
+└── .claude/
+    └── sessions/
+        ├── .gitkeep
+        ├── 2026-02-28-forge-auth.md
+        ├── 2026-02-27-forge-auth.md
+        ├── 2026-02-27-forge-payments.md
+        └── 2026-02-25-jarvis-planning.md
+```
+
+**Naming:** `YYYY-MM-DD-<label>.md`
+- `YYYY-MM-DD` — date of the session
+- `<label>` — agent/task label (e.g., `forge-auth`, `jarvis-planning`, `boris-triage`)
+
+---
+
+## Agent Instructions
+
+### End of Session
+
+```markdown
+## Session Wrap-Up
+Before ending, write a session summary to `.claude/sessions/YYYY-MM-DD-<label>.md`
+using the template from `workflows/session-persistence/session-summary-template.md`.
+
+Include:
+- What was accomplished
+- Key decisions made (and why)
+- What's in-progress / incomplete
+- Next steps for the next session
+- Any blockers
+```
+
+### Start of Session
+
+```markdown
+## Session Resume
+1. Check `.claude/sessions/` for the most recent summary with your label
+2. If found: read it and use it to resume context
+3. If not found: start fresh (no prior context)
+```
+
+---
+
+## Which Agents Use This
+
+| Agent | When to Write | Label Pattern |
+|-------|--------------|---------------|
+| **Forge** | After every build/implementation session | `forge-<task>` |
+| **Jarvis** | After planning or oversight sessions | `jarvis-<context>` |
+| **Boris** | After complex triage sessions | `boris-<date>` |
+| Any sub-agent | After multi-step tasks | `<agent>-<task>` |
+
+---
+
+## Example Summary
+
+```markdown
+# Session Summary: forge-auth — 2026-02-28
+
+## Accomplished
+- Implemented JWT authentication middleware (src/auth/jwt.py)
+- Added token refresh logic (src/auth/refresh.py)
+- 12 tests passing
+
+## Key Decisions
+- Used RS256 (asymmetric) over HS256: better for microservices (can verify without secret)
+- Token expiry: 15min access, 7d refresh (matches industry standard)
+- Stored refresh tokens in Redis, not DB (performance)
+
+## In Progress
+- OAuth provider integration (Google) — 40% done
+  - File: src/auth/oauth.py (created, needs callback handler)
+
+## Next Steps
+1. Implement OAuth callback at /auth/google/callback
+2. Add session invalidation endpoint
+3. Integration test with frontend
+
+## Blockers
+- Need Google OAuth client ID from Dom (check TOOLS.md)
+- Redis not running locally — use docker-compose up redis
+
+## Files Modified
+- src/auth/jwt.py (new)
+- src/auth/refresh.py (new)
+- src/auth/oauth.py (partial)
+- tests/test_auth.py
+```
+
+---
+
+## See Also
+
+- `session-summary-template.md` — Copy-paste template
+- `persistence-script.sh` — Helper to write/read session state from CLI

--- a/workflows/session-persistence/persistence-script.sh
+++ b/workflows/session-persistence/persistence-script.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# persistence-script.sh — Write or read session state for cross-session continuity
+#
+# Usage:
+#   ./persistence-script.sh write <label>    # Open editor to write session summary
+#   ./persistence-script.sh read  <label>    # Read most recent summary for label
+#   ./persistence-script.sh list             # List all session summaries
+#   ./persistence-script.sh latest <label>   # Print path to latest summary for label
+
+set -euo pipefail
+
+SESSIONS_DIR="${SESSIONS_DIR:-.claude/sessions}"
+DATE="$(date +%Y-%m-%d)"
+
+# ─── Ensure sessions directory exists ────────────────────────────────────────
+
+mkdir -p "$SESSIONS_DIR"
+
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+CMD="${1:-}"
+LABEL="${2:-}"
+
+case "$CMD" in
+
+  write)
+    if [[ -z "$LABEL" ]]; then
+      echo "Usage: $0 write <label>"
+      echo "Example: $0 write forge-auth"
+      exit 1
+    fi
+
+    FILENAME="${SESSIONS_DIR}/${DATE}-${LABEL}.md"
+
+    # Bootstrap from template if file doesn't exist
+    if [[ ! -f "$FILENAME" ]]; then
+      cat > "$FILENAME" <<EOF
+# Session Summary: ${LABEL} — ${DATE}
+
+## Accomplished
+- 
+
+## Key Decisions
+- 
+
+## In Progress
+- 
+
+## Next Steps
+1. 
+
+## Blockers
+- (none)
+
+## Files Modified
+- 
+EOF
+      echo "📝 Created: $FILENAME"
+    fi
+
+    # Open in editor
+    EDITOR="${EDITOR:-nano}"
+    "$EDITOR" "$FILENAME"
+    echo "✅ Saved: $FILENAME"
+    ;;
+
+  read)
+    if [[ -z "$LABEL" ]]; then
+      echo "Usage: $0 read <label>"
+      exit 1
+    fi
+
+    LATEST="$(ls -t "${SESSIONS_DIR}"/*"${LABEL}"*.md 2>/dev/null | head -1 || true)"
+
+    if [[ -z "$LATEST" ]]; then
+      echo "No session summary found for label: $LABEL"
+      echo "Sessions directory: $SESSIONS_DIR"
+      exit 0
+    fi
+
+    echo "📖 Reading: $LATEST"
+    echo "---"
+    cat "$LATEST"
+    ;;
+
+  latest)
+    if [[ -z "$LABEL" ]]; then
+      echo "Usage: $0 latest <label>"
+      exit 1
+    fi
+
+    LATEST="$(ls -t "${SESSIONS_DIR}"/*"${LABEL}"*.md 2>/dev/null | head -1 || true)"
+
+    if [[ -z "$LATEST" ]]; then
+      echo "(none)"
+    else
+      echo "$LATEST"
+    fi
+    ;;
+
+  list)
+    echo "📁 Session summaries in ${SESSIONS_DIR}/:"
+    echo ""
+    if ls "${SESSIONS_DIR}"/*.md 2>/dev/null | head -1 > /dev/null; then
+      ls -lt "${SESSIONS_DIR}"/*.md | awk '{print $6, $7, $8, $9}'
+    else
+      echo "  (no summaries yet)"
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 <command> [label]"
+    echo ""
+    echo "Commands:"
+    echo "  write <label>    Write/edit today's session summary"
+    echo "  read  <label>    Read most recent summary for label"
+    echo "  latest <label>   Print path to latest summary for label"
+    echo "  list             List all session summaries"
+    echo ""
+    echo "Examples:"
+    echo "  $0 write forge-auth"
+    echo "  $0 read  forge-auth"
+    echo "  $0 list"
+    exit 1
+    ;;
+
+esac

--- a/workflows/session-persistence/session-summary-template.md
+++ b/workflows/session-persistence/session-summary-template.md
@@ -1,0 +1,86 @@
+# Session Summary Template
+
+Copy this template when writing a session summary at end of session.
+
+**Save to:** `.claude/sessions/YYYY-MM-DD-<label>.md`
+
+---
+
+```markdown
+# Session Summary: <label> — YYYY-MM-DD
+
+## Accomplished
+<!-- What was completed this session (bullet list) -->
+- 
+
+## Key Decisions
+<!-- Decisions made and WHY — context for next session -->
+- 
+
+## In Progress
+<!-- What is partially done (with file locations and % complete if known) -->
+- 
+
+## Next Steps
+<!-- Ordered list of what to do next session -->
+1. 
+
+## Blockers
+<!-- Anything that needs external input or is blocking progress -->
+- (none)
+
+## Files Modified
+<!-- Key files created or changed this session -->
+- 
+
+## Notes
+<!-- Any other context that would help next session start faster -->
+```
+
+---
+
+## Minimal Template (for short sessions)
+
+```markdown
+# Session: <label> — YYYY-MM-DD
+**Done:** <one-line summary of what was accomplished>
+**Next:** <one-line summary of what to do next>
+**Blockers:** <none | describe blockers>
+```
+
+---
+
+## Reading a Previous Summary
+
+At session start, the agent should:
+
+```bash
+# Find the most recent summary for a label
+ls -t .claude/sessions/*<label>*.md | head -1
+
+# Read it
+cat .claude/sessions/2026-02-28-forge-auth.md
+```
+
+Or from within an agent prompt:
+
+```markdown
+## Session Resume Instructions
+1. Run: ls -t .claude/sessions/ | head -5
+2. Find the most recent file matching your session label
+3. Read that file
+4. Begin your session with that context loaded
+```
+
+---
+
+## Multi-Session Example
+
+```
+.claude/sessions/
+├── 2026-02-26-forge-auth.md    ← Day 1: set up skeleton
+├── 2026-02-27-forge-auth.md    ← Day 2: JWT impl
+└── 2026-02-28-forge-auth.md    ← Day 3: OAuth (read THIS one to resume)
+```
+
+Each day's summary builds on the previous. The next agent reads only the latest.


### PR DESCRIPTION
## Summary

Adds three new workflows for parallel Claude work, token-efficient search, and cross-session continuity.

## Workflows Added

### `workflows/git-worktrees/` — Closes #6
- **WORKFLOW.md** — Git worktrees for parallel Claude instances: each agent gets own directory + branch, zero working-directory conflicts
- **setup-worktrees.sh** — Helper script to create worktree + report next steps
- **conventions.md** — Naming conventions (`<repo>-<slug>`), lifecycle, cleanup procedures

### `workflows/mgrep-search/` — Closes #7
- **WORKFLOW.md** — Why mgrep over grep/ripgrep (~50% token reduction), installation, key flags, search→read pattern
- **search-patterns.md** — Common patterns: function defs, class defs, imports, TODOs, error handling, API endpoints, tests
- **migration-guide.md** — Direct translation table from grep/ripgrep to mgrep equivalents

### `workflows/session-persistence/` — Closes #8
- **WORKFLOW.md** — Boris/Forge/Jarvis write summaries to `.claude/sessions/YYYY-MM-DD-<label>.md`; next session reads latest to resume
- **session-summary-template.md** — Full and minimal templates, with read instructions
- **persistence-script.sh** — CLI helper: write/read/list/latest commands
- **.claude/sessions/.gitkeep** — Placeholder for sessions directory

Closes #6
Closes #7
Closes #8